### PR TITLE
Due to inspec deprecation warnings

### DIFF
--- a/libraries/docker_helper.rb
+++ b/libraries/docker_helper.rb
@@ -53,7 +53,7 @@ class DockerHelper < Inspec.resource(1)
   def parse_systemd_values(stdout)
     SimpleConfig.new(
       stdout,
-      assignment_re: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/,
+      assignment_regex: /^\s*([^=]*?)\s*=\s*(.*?)\s*$/,
       multiple_values: false
     ).params
   end


### PR DESCRIPTION
The audit cookbook shows these DEPRECATION warnings during run:
```
       [2017-05-18T15:10:46+00:00] INFO: Running tests from: [{:name=>"cis-docker-benchmark", :url=>"https://github.com/dev-sec/cis-docker-benchmark/archive/1.3.0.tar.gz"}]
       [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
       [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
       [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
       [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
       [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
       [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
       [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
       [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
```