### PR TITLE
name correct minimum inspec version

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ InSpec is an open-source run-time framework and rule language used to specify co
 
 ## Requirements
 
-* at least [InSpec](http://inspec.io/) version 1.21.0
+* at least [InSpec](http://inspec.io/) version 1.38.8
 * Docker 1.13+
 
 ### Platform


### PR DESCRIPTION
The latest version uses the `auditd` resource which was introduced with [InSpec 1.38.8](https://github.com/chef/inspec/blob/master/CHANGELOG.md#v1388-2017-09-23)


Signed-off-by: Christoph Hartmann <chris@lollyrock.com>