### PR TITLE
Fixes #37 prevent NoMethodError when no hosts available

### DIFF
--- a/controls/container_runtime.rb
+++ b/controls/container_runtime.rb
@@ -223,6 +223,7 @@ control 'docker-5.7' do
     container_info = docker.object(id)
     next if container_info['NetworkSettings']['Ports'].nil?
     container_info['NetworkSettings']['Ports'].each do |_, hosts|
+      next if hosts.nil?
       hosts.each do |host|
         describe host['HostPort'].to_i.between?(1, 1024) do
           it { should eq false }
@@ -354,6 +355,7 @@ control 'docker-5.13' do
     container_info = docker.object(id)
     next if container_info['NetworkSettings']['Ports'].nil?
     container_info['NetworkSettings']['Ports'].each do |_, hosts|
+      next if hosts.nil?
       hosts.each do |host|
         describe host['HostIp'].to_i.between?(1, 1024) do
           it { should_not eq '0.0.0.0' }


### PR DESCRIPTION
We are still experiencing NoMethodError due ti the hosts variable that may be nil. Adding these 2 lines of codes was able to fix the issue.