### PR TITLE
Fix utf8 truncated output

### DIFF
--- a/controls/container_images.rb
+++ b/controls/container_images.rb
@@ -178,7 +178,7 @@ control 'docker-4.7' do
   ref 'caching and apt-get update', url: 'https://github.com/moby/moby/issues/3313'
 
   docker.images.ids.each do |id|
-    describe command("docker history #{id}| grep -e 'update'") do
+    describe command("docker --no-trunc history #{id}| grep -e 'update'") do
       its('stdout') { should eq '' }
     end
   end

--- a/controls/container_images.rb
+++ b/controls/container_images.rb
@@ -220,7 +220,7 @@ control 'docker-4.9' do
   ref 'Best practices for writing Dockerfiles', url: 'https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/'
 
   docker.images.ids.each do |id|
-    describe command("docker history #{id}| grep 'ADD'") do
+    describe command("docker --no-trunc history #{id}| grep 'ADD'") do
       its('stdout') { should eq '' }
     end
   end


### PR DESCRIPTION
`controls/container_images.rb` uses `docker history` to inspect commands, which truncates tabular output with a UTF-8 dash, which might lead to character encoding issues (https://github.com/dev-sec/cis-docker-benchmark/issues/51).

`--no-trunc` option to `docker history` mitigates this while preserving check functionality.