### PR TITLE
Removed trailing slashes in 1.8, 1.9

### DIFF
--- a/controls/host_configuration.rb
+++ b/controls/host_configuration.rb
@@ -195,7 +195,7 @@ control 'host-1.8' do
 
   only_if { os.linux? }
   describe auditd do
-    its(:lines) { should include('-w /var/lib/docker/ -p rwxa -k docker') }
+    its(:lines) { should include('-w /var/lib/docker -p rwxa -k docker') }
   end
 end
 
@@ -214,7 +214,7 @@ control 'host-1.9' do
 
   only_if { os.linux? }
   describe auditd do
-    its(:lines) { should include('-w /etc/docker/ -p rwxa -k docker') }
+    its(:lines) { should include('-w /etc/docker -p rwxa -k docker') }
   end
 end
 


### PR DESCRIPTION
Benchmark tests 1.8 and 1.9 had trailing slashes and would thus never pass since auditctl -l removes trailing slashes.

Also compared with the pdf from cis-benchmarks, and they also do not have trailing slashes:
![image](https://user-images.githubusercontent.com/3883897/68696318-0750ad00-057d-11ea-97c4-d48ea15b1c06.png)

![image](https://user-images.githubusercontent.com/3883897/68696300-00c23580-057d-11ea-89a2-1885c84f28d5.png)

